### PR TITLE
Fix Boost 1.60 compatibility

### DIFF
--- a/src/normalizer/rulebased/rule.cpp
+++ b/src/normalizer/rulebased/rule.cpp
@@ -249,10 +249,6 @@ std::size_t RuleHasher::operator()(const Rule& r) const {
     return std::hash<std::string>()(s);
 }
 
-}  // namespace Rulebased
-}  // namespace Normalizer
-}  // namespace Norma
-
 std::ostream& operator<<(std::ostream& strm,
                          const Norma::Normalizer::Rulebased::Rule& r) {
     strm << "{" << r.from() << "->" << r.to()
@@ -266,3 +262,6 @@ std::ostream& operator<<(std::ostream& strm,
         strm << *rule << std::endl;
     return strm;
 }
+}  // namespace Rulebased
+}  // namespace Normalizer
+}  // namespace Norma

--- a/src/normalizer/rulebased/rule.h
+++ b/src/normalizer/rulebased/rule.h
@@ -91,6 +91,7 @@ class Rule {
          return !(*this == that);
      }
      bool operator<(const Rule& that) const;
+     friend std::ostream& operator<<(std::ostream& strm, const Rule& r);
 
  protected:
      Rule() = default;
@@ -139,6 +140,8 @@ class RuleSet {
                    const string_impl& source, size_t spos,
                    const string_impl& target, size_t tpos);
 
+     friend std::ostream& operator<<(std::ostream& strm, const RuleSet& rs);
+
  protected:
      /// just push a rule on the vector
      /// protected since it might confuse the rest of the
@@ -177,16 +180,16 @@ struct RuleHasher {
     std::size_t operator()(const Rule& r) const;
 };
 
+/// ostream operator to ensure Rules can be outputted to cout or file
+std::ostream& operator<<(std::ostream& strm,
+                         const Rule& r);
+
+/// ostream operator to ensure RuleSet can be outputted to cout or file
+std::ostream& operator<<(std::ostream& strm,
+                         const RuleSet& rs);
 }  // namespace Rulebased
 }  // namespace Normalizer
 }  // namespace Norma
 
-/// ostream operator to ensure Rules can be outputted to cout or file
-std::ostream& operator<<(std::ostream& strm,
-                         const Norma::Normalizer::Rulebased::Rule& r);
-
-/// ostream operator to ensure RuleSet can be outputted to cout or file
-std::ostream& operator<<(std::ostream& strm,
-                         const Norma::Normalizer::Rulebased::RuleSet& rs);
 #endif  // NORMALIZER_RULEBASED_RULE_H_
 

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -18,30 +18,5 @@
 #ifndef TESTS_TESTS_H_
 #define TESTS_TESTS_H_
 #include<boost/test/included/unit_test.hpp>
-#include"string_impl.h"
-#include"normalizer/rulebased/rule.h"
-
-// Make BOOST_x_EQUAL work with string_impl
-// --taken from <http://stackoverflow.com/questions/17572583/boost-check-fails-to-compile-operator-for-custom-types>
-
-namespace boost {
-namespace test_tools {
-#ifdef USE_ICU_STRING
-template<>
-struct print_log_value<string_impl> {
-    void operator()(std::ostream& os, string_impl const& si) {  // NOLINT[runtime/references]
-        ::operator<<(os, si);
-    }
-};
-#endif  // USE_ICU_STRING
-
-template<>
-struct print_log_value<Norma::Normalizer::Rulebased::Rule> {
-    void operator()(std::ostream& os, Norma::Normalizer::Rulebased::Rule const& r) {  // NOLINT[runtime/references]
-        ::operator<<(os, r);
-    }
-};
-}  // namespace test_tools
-}  // namespace boost
 
 #endif  // TESTS_TESTS_H_


### PR DESCRIPTION
Tests compile and pass for me using Boost 1.60.0.

re #11 